### PR TITLE
Add a second SummaryWriter to add date in the outputPath.

### DIFF
--- a/LightBDD/Configuration/LightBDDConfiguration.cs
+++ b/LightBDD/Configuration/LightBDDConfiguration.cs
@@ -7,6 +7,7 @@ namespace LightBDD.Configuration
     /// </summary>
     internal class LightBDDConfiguration : ConfigurationSection
     {
+        private const string WRITER_FIELD = "writer";
         private const string SUMMARY_WRITERS_FIELD = "summaryWriters";
         private const string STEP_TYPES_FIELD = "stepTypes";
 
@@ -30,6 +31,13 @@ namespace LightBDD.Configuration
         {
             get { return (StepTypesElement)this[STEP_TYPES_FIELD]; }
             set { this[STEP_TYPES_FIELD] = value; }
+        }
+
+        [ConfigurationProperty(WRITER_FIELD)]
+        public WriterElement Writer
+        {
+            get { return (WriterElement)this[WRITER_FIELD]; }
+            set { this[WRITER_FIELD] = value; }
         }
     }
 }

--- a/LightBDD/Configuration/WriterElement.cs
+++ b/LightBDD/Configuration/WriterElement.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel;
+using System.Configuration;
+using LightBDD.Results.Formatters;
+using LightBDD.SummaryGeneration;
+
+namespace LightBDD.Configuration
+{
+    /// <summary>
+    /// Summary writer element allowing to associate formatter to output path.
+    /// </summary>
+    internal class WriterElement : ConfigurationElement
+    {
+        private const string TYPE_FIELD = "type";
+
+        /// <summary>
+        /// Type of IResultFormatter used by summary writer.
+        /// </summary>
+        [ConfigurationProperty(TYPE_FIELD, IsRequired = true)]
+        [SubclassTypeValidator(typeof(ISummaryWriter))]
+        [TypeConverter(typeof(TypeNameConverter))]
+        public Type SummaryWriter
+        {
+            get { return (Type)this[TYPE_FIELD]; }
+            set { this[TYPE_FIELD] = value; }
+        }
+
+    }
+}

--- a/LightBDD/Coordination/SummaryGeneratorFactory.cs
+++ b/LightBDD/Coordination/SummaryGeneratorFactory.cs
@@ -11,14 +11,18 @@ namespace LightBDD.Coordination
         public static SummaryGenerator Create()
         {
             var cfg = LightBDDConfiguration.GetConfiguration();
-            return new SummaryGenerator(cfg.SummaryWriters.OfType<SummaryWriterElement>().Select(CreateSummaryOutput).ToArray());
+            return new SummaryGenerator(cfg.SummaryWriters.OfType<SummaryWriterElement>().Select(swe => CreateSummaryOutput(cfg, swe)).ToArray());
         }
 
-        private static SummaryFileWriter CreateSummaryOutput(SummaryWriterElement summaryWriterElement)
+        private static ISummaryWriter CreateSummaryOutput(LightBDDConfiguration cfg, SummaryWriterElement summaryWriterElement)
         {
-            return new SummaryFileWriter(
-                (IResultFormatter)Activator.CreateInstance(summaryWriterElement.Formatter),
-                summaryWriterElement.Output);
+            Type typeFormatter = cfg.Writer.SummaryWriter ?? typeof(SummaryFileWriter);
+
+            IResultFormatter formatter = (IResultFormatter)Activator.CreateInstance(summaryWriterElement.Formatter);
+
+            object[] param = new object[] {formatter, summaryWriterElement.Output};
+
+            return (ISummaryWriter)Activator.CreateInstance(typeFormatter, param);
         }
     }
 }

--- a/LightBDD/LightBDD.csproj
+++ b/LightBDD/LightBDD.csproj
@@ -48,6 +48,7 @@
       <Link>Properties\AssemblyVersion.cs</Link>
     </Compile>
     <Compile Include="AbstractBDDRunner.cs" />
+    <Compile Include="Configuration\WriterElement.cs" />
     <Compile Include="Configuration\StepTypesElement.cs" />
     <Compile Include="Execution\Exceptions\StepBypassException.cs" />
     <Compile Include="Execution\Implementation\ExecutionContext.cs" />
@@ -113,6 +114,7 @@
     <Compile Include="Coordination\FeatureCoordinator.cs" />
     <Compile Include="StepType.cs" />
     <Compile Include="SummaryGeneration\ISummaryWriter.cs" />
+    <Compile Include="SummaryGeneration\SummaryFileWriterCurrentDate.cs" />
     <Compile Include="SummaryGeneration\SummaryGenerator.cs" />
     <Compile Include="SummaryGeneration\SummaryFileWriter.cs" />
     <Compile Include="TestMetadataProvider.cs" />

--- a/LightBDD/SummaryGeneration/SummaryFileWriterCurrentDate.cs
+++ b/LightBDD/SummaryGeneration/SummaryFileWriterCurrentDate.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using LightBDD.Results;
+using LightBDD.Results.Formatters;
+
+namespace LightBDD.SummaryGeneration
+{
+    /// <summary>
+    /// Summary file writer class allows to save feature results by using associated result formatter and output path.
+    /// The output file will be formatted with the current date and time.
+    /// </summary>
+    public class SummaryFileWriterCurrentDate : ISummaryWriter
+    {
+        private readonly SummaryFileWriter _writer;
+
+        /// <summary>
+        /// Constructor allowing to create SummaryFileWriter with associated result formatter and output path.
+        /// </summary>
+        /// <param name="formatter">Result formatter.</param>
+        /// <param name="outputPath">Output path. If starts with ~, it would be resolved to CurrentDomain.BaseDirectory.</param>
+        public SummaryFileWriterCurrentDate(IResultFormatter formatter, string outputPath)
+        {
+            _writer = new SummaryFileWriter(formatter, string.Format(outputPath, DateTime.Now));
+        }
+        
+        /// <summary>
+        /// Saves formatted feature <c>results</c> to file specified in constructor.
+        /// If output path refers to directory which does not exist, it will be created.
+        /// </summary>
+        /// <param name="results">Results to save.</param>
+        public void Save(params IFeatureResult[] results)
+        {
+            _writer.Save(results);
+        }
+    }
+}


### PR DESCRIPTION
I would like to have a new feature to customize the name of the outputPath. I want to drop the file to a network folder and adding the date in the name (or the name of a folder).

Exemple :
\\SharedFolder\Report\{0:yyyy-MM-dd}\MyReport_{0:HH_mm_ss}.html

